### PR TITLE
Remove CSV export feature from admin

### DIFF
--- a/src/pages/AdminCultura.tsx
+++ b/src/pages/AdminCultura.tsx
@@ -108,11 +108,6 @@ import {
   deleteAdminEvent,
   deleteAdminNews,
   deleteAdminSession,
-  exportAdminBooksCsv,
-  exportAdminEventsCsv,
-  exportAdminNewsCsv,
-  exportAdminRegistrationsCsv,
-  exportAdminSessionsCsv,
   fetchAdminDashboard,
   fetchAdminNotifications,
   InfoCulturaAdminNotification,
@@ -213,8 +208,6 @@ import {
   UserFormState,
 } from './adminCultura/types';
 import {
-  downloadBlobFile,
-  escapeCsvValue,
   formatAdminDateTime,
   getActivityRoute,
   getActivitySubpage,
@@ -379,11 +372,6 @@ function AdminCultura() {
   const [registrationTotalPages, setRegistrationTotalPages] = useState(0);
   const [selectedRegistrationIds, setSelectedRegistrationIds] = useState<number[]>([]);
   const [bulkRegistrationStatus, setBulkRegistrationStatus] = useState('approved');
-  const [isExportingNews, setIsExportingNews] = useState(false);
-  const [isExportingActivities, setIsExportingActivities] = useState(false);
-  const [isExportingUsers, setIsExportingUsers] = useState(false);
-  const [isExportingClubs, setIsExportingClubs] = useState(false);
-  const [isExportingRegistrations, setIsExportingRegistrations] = useState(false);
   const [isApplyingBulkNews, setIsApplyingBulkNews] = useState(false);
   const [isApplyingBulkEvents, setIsApplyingBulkEvents] = useState(false);
   const [isApplyingBulkRegistrations, setIsApplyingBulkRegistrations] = useState(false);
@@ -929,171 +917,6 @@ function AdminCultura() {
     event.preventDefault();
     setActivityPage(1);
     setActivitySearch(activitySearchInput.trim());
-  }
-
-  async function handleExportNewsCsv() {
-    if (!token) return;
-
-    setIsExportingNews(true);
-    setNewsError('');
-
-    try {
-      const blob = await exportAdminNewsCsv(token, {
-        clubId: canManageUsers && newsClubFilter !== 'all' ? Number(newsClubFilter) : undefined,
-        status: newsStatusFilter,
-        search: newsSearch,
-        ordering: newsOrder,
-        dateFrom: newsDateFrom,
-        dateTo: newsDateTo
-      });
-      downloadBlobFile(blob, 'infocultura-news.csv');
-    } catch (error) {
-      const message =
-        error instanceof Error ? error.message : 'Nao foi possivel exportar as noticias.';
-      setNewsError(message);
-    } finally {
-      setIsExportingNews(false);
-    }
-  }
-
-  async function handleExportActivitiesCsv() {
-    if (!token) return;
-
-    setIsExportingActivities(true);
-    setActivityError('');
-
-    const clubId =
-      canManageUsers && activityClubFilter !== 'all' ? Number(activityClubFilter) : undefined;
-
-    try {
-      const blob =
-        activityTab === 'books'
-          ? await exportAdminBooksCsv(token, {
-              clubId,
-              search: activitySearch,
-              ordering: activityOrder,
-              dateFrom: activityDateFrom,
-              dateTo: activityDateTo
-            })
-          : activityTab === 'sessions'
-            ? await exportAdminSessionsCsv(token, {
-                clubId,
-                search: activitySearch,
-                ordering: activityOrder,
-                dateFrom: activityDateFrom,
-                dateTo: activityDateTo
-              })
-            : await exportAdminEventsCsv(token, {
-                clubId,
-                categoryId:
-                  activityCategoryFilter !== 'all'
-                    ? Number(activityCategoryFilter)
-                    : undefined,
-                status: activityStatusFilter,
-                search: activitySearch,
-                ordering: activityOrder,
-                dateFrom: activityDateFrom,
-                dateTo: activityDateTo
-              });
-
-      const filename =
-        activityTab === 'books'
-          ? 'infocultura-books.csv'
-          : activityTab === 'sessions'
-            ? 'infocultura-sessions.csv'
-            : 'infocultura-events.csv';
-      downloadBlobFile(blob, filename);
-    } catch (error) {
-      const message =
-        error instanceof Error ? error.message : 'Nao foi possivel exportar a lista atual.';
-      setActivityError(message);
-    } finally {
-      setIsExportingActivities(false);
-    }
-  }
-
-  async function handleExportUsersCsv() {
-    setIsExportingUsers(true);
-    setPanelError('');
-
-    try {
-      const rows = [
-        ['id', 'name', 'email', 'role', 'club', 'is_active', 'created_at'],
-        ...filteredUsers.map((user) => [
-          user.id,
-          user.name,
-          user.email,
-          user.role,
-          user.club_name || '',
-          user.is_active ? 'sim' : 'nao',
-          user.created_at || ''
-        ])
-      ];
-      const csvText = rows.map((row) => row.map((value) => escapeCsvValue(value)).join(',')).join('\n');
-      downloadBlobFile(new Blob([csvText], { type: 'text/csv;charset=utf-8' }), 'infocultura-users.csv');
-    } catch (error) {
-      const message =
-        error instanceof Error ? error.message : 'Nao foi possivel exportar os utilizadores.';
-      setPanelError(message);
-    } finally {
-      setIsExportingUsers(false);
-    }
-  }
-
-  async function handleExportClubsCsv() {
-    setIsExportingClubs(true);
-    setPanelError('');
-
-    try {
-      const rows = [
-        ['id', 'name', 'description', 'mission', 'is_active', 'enable_registrations', 'created_at'],
-        ...filteredClubs.map((club) => [
-          club.id,
-          club.name,
-          club.description,
-          club.mission,
-          club.is_active ? 'sim' : 'nao',
-          club.enable_registrations ? 'sim' : 'nao',
-          club.created_at || ''
-        ])
-      ];
-      const csvText = rows.map((row) => row.map((value) => escapeCsvValue(value)).join(',')).join('\n');
-      downloadBlobFile(new Blob([csvText], { type: 'text/csv;charset=utf-8' }), 'infocultura-clubs.csv');
-    } catch (error) {
-      const message =
-        error instanceof Error ? error.message : 'Nao foi possivel exportar os clubes.';
-      setPanelError(message);
-    } finally {
-      setIsExportingClubs(false);
-    }
-  }
-
-  async function handleExportRegistrationsCsv() {
-    if (!token) return;
-
-    setIsExportingRegistrations(true);
-    setRegistrationError('');
-
-    try {
-      const blob = await exportAdminRegistrationsCsv(token, {
-        clubId:
-          canManageUsers && registrationClubFilter !== 'all'
-            ? Number(registrationClubFilter)
-            : undefined,
-        status: registrationStatusFilter,
-        search: registrationSearch,
-        ordering: registrationOrder,
-        dateFrom: registrationDateFrom,
-        dateTo: registrationDateTo
-      });
-      downloadBlobFile(blob, 'infocultura-registrations.csv');
-    } catch (error) {
-      const message =
-        error instanceof Error ? error.message : 'Nao foi possivel exportar as inscricoes.';
-      setRegistrationError(message);
-    } finally {
-      setIsExportingRegistrations(false);
-    }
   }
 
   function toggleSelectedId(setter: Dispatch<SetStateAction<number[]>>, id: number) {
@@ -2685,8 +2508,6 @@ function AdminCultura() {
             <UsersPage
               userPage={userPage}
               canManageUsers={canManageUsers}
-              isExportingUsers={isExportingUsers}
-              handleExportUsersCsv={handleExportUsersCsv}
               userOverviewStats={userOverviewStats}
               isLoadingUsers={isLoadingUsers}
               filteredUsers={filteredUsers}
@@ -2714,8 +2535,6 @@ function AdminCultura() {
           {activeSection === 'clubes' ? (
             <ClubsPage
               clubsOverviewStats={clubsOverviewStats}
-              isExportingClubs={isExportingClubs}
-              handleExportClubsCsv={handleExportClubsCsv}
               handleSaveClub={handleSaveClub}
               clubForm={clubForm}
               setClubForm={setClubForm}
@@ -2752,8 +2571,6 @@ function AdminCultura() {
             <NewsPage
               canManageUsers={canManageUsers}
               newsOverviewStats={newsOverviewStats}
-              isExportingNews={isExportingNews}
-              handleExportNewsCsv={handleExportNewsCsv}
               showNewsForm={showNewsForm}
               showNewsList={showNewsList}
               handleSaveNews={handleSaveNews}
@@ -2811,8 +2628,6 @@ function AdminCultura() {
               activitySectionLabel={activitySectionLabel}
               activitySectionDescription={activitySectionDescription}
               activityOverviewStats={activityOverviewStats}
-              isExportingActivities={isExportingActivities}
-              handleExportActivitiesCsv={handleExportActivitiesCsv}
               showActivityFiltersAndList={showActivityFiltersAndList}
               canManageUsers={canManageUsers}
               clubs={clubs}
@@ -2914,8 +2729,6 @@ function AdminCultura() {
               activitySectionLabel={activitySectionLabel}
               activitySectionDescription={activitySectionDescription}
               activityOverviewStats={activityOverviewStats}
-              isExportingActivities={isExportingActivities}
-              handleExportActivitiesCsv={handleExportActivitiesCsv}
               showActivityFiltersAndList={showActivityFiltersAndList}
               canManageUsers={canManageUsers}
               clubs={clubs}
@@ -3016,8 +2829,6 @@ function AdminCultura() {
               activitySectionLabel={activitySectionLabel}
               activitySectionDescription={activitySectionDescription}
               activityOverviewStats={activityOverviewStats}
-              isExportingActivities={isExportingActivities}
-              handleExportActivitiesCsv={handleExportActivitiesCsv}
               showActivityFiltersAndList={showActivityFiltersAndList}
               canManageUsers={canManageUsers}
               clubs={clubs}
@@ -3116,8 +2927,6 @@ function AdminCultura() {
           {activeSection === 'inscricoes' ? (
             <RegistrationsPage
               registrationOverviewStats={registrationOverviewStats}
-              isExportingRegistrations={isExportingRegistrations}
-              handleExportRegistrationsCsv={handleExportRegistrationsCsv}
               registrationTotal={registrationTotal}
               pendingRegistrations={pendingRegistrations}
               approvedRegistrations={approvedRegistrations}

--- a/src/pages/adminCultura/ActivitiesPage.tsx
+++ b/src/pages/adminCultura/ActivitiesPage.tsx
@@ -47,8 +47,6 @@ export type ActivitiesPageProps = {
   activitySectionLabel: string;
   activitySectionDescription: string;
   activityOverviewStats: AdminHeroStat[];
-  isExportingActivities: boolean;
-  handleExportActivitiesCsv: () => void | Promise<void>;
   showActivityFiltersAndList: boolean;
   canManageUsers: boolean;
   clubs: InfoCulturaClub[];
@@ -148,8 +146,6 @@ function ActivitiesPage({
   activitySectionLabel,
   activitySectionDescription,
   activityOverviewStats,
-  isExportingActivities,
-  handleExportActivitiesCsv,
   showActivityFiltersAndList,
   canManageUsers,
   clubs,
@@ -252,16 +248,6 @@ function ActivitiesPage({
         description={activitySectionDescription}
         tone="blue"
         stats={activityOverviewStats}
-        actions={
-          <button
-            type="button"
-            className={adminBtnSecondary}
-            onClick={() => void handleExportActivitiesCsv()}
-            disabled={isExportingActivities}
-          >
-            {isExportingActivities ? 'A exportar...' : 'Exportar CSV'}
-          </button>
-        }
       />
 
       {showActivityFiltersAndList ? (

--- a/src/pages/adminCultura/ClubsPage.tsx
+++ b/src/pages/adminCultura/ClubsPage.tsx
@@ -46,8 +46,6 @@ type AdminHeroStat = { label: string; value: string | number };
 
 type ClubsPageProps = {
   clubsOverviewStats: AdminHeroStat[];
-  isExportingClubs: boolean;
-  handleExportClubsCsv: () => void | Promise<void>;
   handleSaveClub: (event: FormEvent<HTMLFormElement>) => void;
   clubForm: ClubFormState;
   setClubForm: Dispatch<SetStateAction<ClubFormState>>;
@@ -81,8 +79,6 @@ type ClubsPageProps = {
 
 function ClubsPage({
   clubsOverviewStats,
-  isExportingClubs,
-  handleExportClubsCsv,
   handleSaveClub,
   clubForm,
   setClubForm,
@@ -121,16 +117,6 @@ function ClubsPage({
         description="Estrutura interna dos clubes, estados de atividade e configuracao de inscricoes."
         tone="amber"
         stats={clubsOverviewStats}
-        actions={
-          <button
-            type="button"
-            className={adminBtnSecondary}
-            onClick={() => void handleExportClubsCsv()}
-            disabled={isExportingClubs}
-          >
-            {isExportingClubs ? 'A exportar...' : 'Exportar CSV'}
-          </button>
-        }
       />
 
       <form onSubmit={handleSaveClub} className={adminPanelForm}>

--- a/src/pages/adminCultura/NewsPage.tsx
+++ b/src/pages/adminCultura/NewsPage.tsx
@@ -43,8 +43,6 @@ type AdminHeroStat = { label: string; value: string | number };
 type NewsPageProps = {
   canManageUsers: boolean;
   newsOverviewStats: AdminHeroStat[];
-  isExportingNews: boolean;
-  handleExportNewsCsv: () => void | Promise<void>;
   showNewsForm: boolean;
   showNewsList: boolean;
   handleSaveNews: (event: FormEvent<HTMLFormElement>) => void;
@@ -99,8 +97,6 @@ type NewsPageProps = {
 function NewsPage({
   canManageUsers,
   newsOverviewStats,
-  isExportingNews,
-  handleExportNewsCsv,
   showNewsForm,
   showNewsList,
   handleSaveNews,
@@ -159,16 +155,6 @@ function NewsPage({
         description="Workflow editorial, publicacao e acompanhamento das noticias por clube."
         tone="blue"
         stats={newsOverviewStats}
-        actions={
-          <button
-            type="button"
-            className={adminBtnSecondary}
-            onClick={() => void handleExportNewsCsv()}
-            disabled={isExportingNews}
-          >
-            {isExportingNews ? 'A exportar...' : 'Exportar CSV'}
-          </button>
-        }
       />
 
       {showNewsForm ? (

--- a/src/pages/adminCultura/RegistrationsPage.tsx
+++ b/src/pages/adminCultura/RegistrationsPage.tsx
@@ -43,8 +43,6 @@ type AdminHeroStat = { label: string; value: string | number };
 
 type RegistrationsPageProps = {
   registrationOverviewStats: AdminHeroStat[];
-  isExportingRegistrations: boolean;
-  handleExportRegistrationsCsv: () => void | Promise<void>;
   registrationTotal: number;
   pendingRegistrations: number;
   approvedRegistrations: number;
@@ -100,8 +98,6 @@ function getRegistrationStatusBadge(status: string): string {
 
 function RegistrationsPage({
   registrationOverviewStats,
-  isExportingRegistrations,
-  handleExportRegistrationsCsv,
   registrationTotal,
   pendingRegistrations,
   approvedRegistrations,
@@ -148,16 +144,6 @@ function RegistrationsPage({
         description="Consulta, triagem e validacao dos pedidos submetidos pelos clubes."
         tone="rose"
         stats={registrationOverviewStats}
-        actions={
-          <button
-            type="button"
-            className={adminBtnSecondary}
-            onClick={() => void handleExportRegistrationsCsv()}
-            disabled={isExportingRegistrations}
-          >
-            {isExportingRegistrations ? 'A exportar...' : 'Exportar CSV'}
-          </button>
-        }
       />
 
       <section className={adminPanelCard}>

--- a/src/pages/adminCultura/UsersPage.tsx
+++ b/src/pages/adminCultura/UsersPage.tsx
@@ -37,8 +37,6 @@ type AdminHeroStat = { label: string; value: string | number };
 type UsersPageProps = {
   userPage: UserPage | null;
   canManageUsers: boolean;
-  isExportingUsers: boolean;
-  handleExportUsersCsv: () => void | Promise<void>;
   userOverviewStats: AdminHeroStat[];
   isLoadingUsers: boolean;
   filteredUsers: InfoCulturaUser[];
@@ -65,8 +63,6 @@ type UsersPageProps = {
 function UsersPage({
   userPage,
   canManageUsers,
-  isExportingUsers,
-  handleExportUsersCsv,
   userOverviewStats,
   isLoadingUsers,
   filteredUsers,
@@ -106,14 +102,6 @@ function UsersPage({
               <NavLink to="/infocultura/utilizadores/novo" className={adminBtnPrimary}>
                 Criar utilizador
               </NavLink>
-              <button
-                type="button"
-                className={adminBtnSecondary}
-                onClick={() => void handleExportUsersCsv()}
-                disabled={isExportingUsers}
-              >
-                {isExportingUsers ? 'A exportar...' : 'Exportar CSV'}
-              </button>
             </>
           ) : undefined
         }


### PR DESCRIPTION
Remove the CSV export functionality and related UI/logic across the admin Cultura area. Deleted export handlers (handleExportNewsCsv, handleExportActivitiesCsv, handleExportUsersCsv, handleExportClubsCsv, handleExportRegistrationsCsv), removed isExporting state flags and CSV helper imports (downloadBlobFile, escapeCsvValue) and removed imports of export API functions. Also removed export buttons and related props passed to ActivitiesPage, ClubsPage, NewsPage, RegistrationsPage and UsersPage. This cleans up unused export code and UI surfaces.